### PR TITLE
Hashing update

### DIFF
--- a/AlpheusUnitTests/HashingTests.fs
+++ b/AlpheusUnitTests/HashingTests.fs
@@ -154,6 +154,24 @@ type FastHashTests(output)=
             Assert.True(System.IO.File.Exists(hashFilePath))
         } |> toAsyncFact
 
+    
+    [<Fact>]
+    member s. ``Hidden files are excluded from hash calculation`` () =
+        async {
+            let! hash1 = ItisLab.Alpheus.Hash.hashDirectoryAsync s.Path
+    
+            let hidFileName = System.IO.Path.Combine(s.Path,".gitfile1")
+    
+            do! File.WriteAllTextAsync(hidFileName,"test hidden files") |> Async.AwaitTask
+            let initialAttrs = File.GetAttributes(hidFileName)
+            File.SetAttributes(hidFileName, initialAttrs ||| FileAttributes.Hidden)
+    
+            let! hash2 = ItisLab.Alpheus.Hash.hashDirectoryAsync s.Path
+    
+            assertByteArraysEqual hash1 hash2
+    
+        } |> toAsyncFact
+
     [<Fact>]
     member s.``Fast hash respects up-to-date dot-hash file for file artefact`` () =
         async {


### PR DESCRIPTION
### Omitting of the hidden files during hashing

Some files must not be accounted during hashing

**Reason**
Some programs (e.g. Windows Explorer) can create hidden service files on disk (e.g. image thumbnails files). These files are irrelevant to alpheus produced artefact.

### Speeding up hashing

Enabling asynchronous file modification time extraction and files attribute extraction.

**Reason**
Synchronous enumerating modification times of tens thousand files becomes considerably long operation.