### PR TITLE
Enable syncronization of methods on resources

### DIFF
--- a/Alpheus.CLI/BuildCommand.fs
+++ b/Alpheus.CLI/BuildCommand.fs
@@ -23,12 +23,13 @@ let run workingDir (buildArgs:ParseResults<BuildArgs>) =
             { 
                 DependencyGraph.CommandExecutionSettings.Default with
                     DoNotCleanOutputs = buildArgs.Contains Disable_Outputs_Clean
+
             }
 
         if settings.DoNotCleanOutputs then
             Logger.logVerbose Logger.CLI "Clearing of outputs is disabled for this command execution"
 
-        let settings2 =
+        let settings =
             match buildArgs.TryGetResult Successful_Exit_Codes with
             |   Some(codes) ->
                 Logger.logVerbose Logger.CLI (sprintf "Custom exit codes are considered as successful exit: %A" codes)
@@ -36,9 +37,17 @@ let run workingDir (buildArgs:ParseResults<BuildArgs>) =
             |   None ->
                 settings
 
+        let settings =
+            match buildArgs.TryGetResult Resource_Group with
+            |   Some(groups) ->
+                Logger.logVerbose Logger.CLI (sprintf "Resource groups were set: %A" groups)
+                {settings with ResourceGroups = set groups }
+            |   None ->
+                settings
+
         match roots with
         | [] -> return! Error (UserError "An output artefact is not specified")
         | [None] -> return! Error (UserError "Not an experiment folder: .alpheus")
-        | [Some experimentRoot] -> return! (API.buildAsync experimentRoot workingDir deps outputs command settings2 |> Async.RunSynchronously)
+        | [Some experimentRoot] -> return! (API.buildAsync experimentRoot workingDir deps outputs command settings |> Async.RunSynchronously)
         | _ -> return! Error (UserError "Not all of the input or output artefacts are under the same experiment root folder")
     }

--- a/Alpheus.CLI/Cli.fs
+++ b/Alpheus.CLI/Cli.fs
@@ -39,6 +39,7 @@ with
 type BuildArgs = 
     |   D of dependency:string
     |   O of output:string
+    |   [<CliPrefix(CliPrefix.DoubleDash)>][<AltCommandLine("-rg")>]Resource_Group of resourceGroups: string list
     |   [<CliPrefix(CliPrefix.DoubleDash)>]Disable_Outputs_Clean
     |   [<CliPrefix(CliPrefix.DoubleDash)>][<AltCommandLine("-ec")>]Successful_Exit_Codes of codes:int list
     | [<Last;CliPrefix(CliPrefix.None)>]Command
@@ -48,6 +49,7 @@ with
             match s with
             |   D _ -> "Dependency path (file or folder)"
             |   O _ -> "Output path (file or folder)"
+            |   Resource_Group _ -> "Include current command to some resource group (e.g. \"GPU\", \"DiskIO\", \"RAM\" etc.  any arbitrary string). Space separated strings. Command does not belong to any group by default."
             |   Disable_Outputs_Clean -> "Make the command responsible for clearing the outputs in case of re-computation. Useful for resumable computations. Default: The outputs are cleaned by alpheus"
             |   Successful_Exit_Codes _ -> "Exit codes (space separated) of the command that are considered as successful computation. Default: 0"
             |   Command _ -> "Command that generates the outputs"

--- a/AlpheusCore/AlphFiles.fs
+++ b/AlpheusCore/AlphFiles.fs
@@ -28,6 +28,8 @@ type VersionedArtefact = {
 type CommandOutput =  {
     Inputs: VersionedArtefact list
     Outputs: VersionedArtefact list
+    /// Used for limiting concurrent execution of several command vertices that require same limited resource. e.g. GPU, disk throughput, etc
+    ResourceGroups: string list
     SuccessfulExitCodes: int list
     OutputIndex: int
     WorkingDirectory: AlphRelativePath

--- a/AlpheusCore/ExecuteCommand.fs
+++ b/AlpheusCore/ExecuteCommand.fs
@@ -85,11 +85,10 @@ let runCmdLocallyAsync print outputAnnotationId program args (workingDir:string)
 
 /// Runs the command line method and waits indefinitely until the process exits.
 /// Returns the exit code.
-let runCommandLineMethodAndWait (context: ComputationContext) (input: int -> string, output: int -> string) (computation: CommandLineVertex) =
+let runCommandLineMethodAndWaitAsync (context: ComputationContext) (input: int -> string, output: int -> string) (computation: CommandLineVertex) =
     let command = computation.Command.Trim() |> MethodCommand.substitute (input, output)
     let program,args = MethodCommand.split command                 
     let wdAbsPath = context.GetAbsolutePath(computation.WorkingDirectory)
-    let localComputation = runCmdLocallyAsync context.Print computation.MethodId program args wdAbsPath 
-    Async.RunSynchronously localComputation
+    runCmdLocallyAsync context.Print computation.MethodId program args wdAbsPath
 
     


### PR DESCRIPTION
closes #29 
By introducing the ability to specify that method belongs to one or many resource groups.
Only one method of resource group can execute at a time.