### PR TITLE
Dgrechka/issue89

### DIFF
--- a/AlpheusCore/ActualVersion.fs
+++ b/AlpheusCore/ActualVersion.fs
@@ -39,6 +39,7 @@ type ActualArtefactVersion(id: ArtefactId, experimentRoot: string) =
         lock versionLock (fun() -> version <- version |> MdMap.add index (lazyReadVersion index))
 
     /// Gets an actual version for the given exact index.
+    /// None means that there is nothing on disk
     member s.Get (index: string list) : Async<HashString option> =
         checkRank index
         let factory = 

--- a/AlpheusCore/ComputationGraph.fs
+++ b/AlpheusCore/ComputationGraph.fs
@@ -43,20 +43,22 @@ type SourceMethod(source: SourceVertex, experimentRoot) =
             let! actualVersionsStrached = actualIndices |> Seq.map artefact.ActualVersion.Get |> Async.Parallel
             let actualVersions = Seq.zip actualIndices actualVersionsStrached |> Seq.fold (fun s e -> let k,v = e in MdMap.add k v s) MdMap.empty
 
-            let merger _ expectedOpt actualOpt = expectedOpt,actualOpt
+            let merger _ expectedOpt actualOpt = (Option.flatten expectedOpt), (Option.flatten actualOpt)
             let expAndAct = Utils.mdmapMerge merger expectedVersions actualVersions
 
             let alphExists = source.Output.Artefact.Id |> PathUtils.idToAlphFileFullPath source.ExperimentRoot |> File.Exists
             // 1. Update Alph file (if needed)
             // if alph file exists on disk (e.g. isTracked), we need to re-save it to update the expected version
-            if alphExists then
+            // also we need to save alph file in case we have vector output. It is needed to track which indices were generate on previous run
+            // on the updated data run, the indices that disapperead will be propagated as delete operation
+            if alphExists || (not expAndAct.IsScalar) then
                 // we need to update (expect actual in) alph file only if there is something on disk
                 // otherwise the artefact can be saved and restored later from storages, so we do not need to override expectations
                 let doUpdateAlphFile = expAndAct |> MdMap.toSeq |> Seq.exists (fun p -> let _,(_,actual) = p in actual.IsSome)
                 if doUpdateAlphFile then
                     do! expAndAct |> MdMap.toSeq |> Seq.map (fun p -> let idx,_  = p in source.Output.ExpectActualVersionAsync idx) |>  Async.Parallel |> Async.Ignore
-                    artefact.SaveAlphFile()            
                     Logger.logVerbose Logger.DependencyGraph (sprintf "Written alph file for source artefact (%O), as there is some data for the artefact on disk" source.Output)
+                artefact.SaveAlphFile()
             
             // 2. Constructing the ArtefactItem[s] and pass them as method result
             // Output of the method is an scalar or a vector of full paths to the data of the artefact.
@@ -67,11 +69,24 @@ type SourceMethod(source: SourceVertex, experimentRoot) =
                 |   Some(_), None -> Delete
                 |   None, Some(_) -> Process
                 |   None,None -> Delete // why this can happen?
+            let diskItemExists pair =
+                let expectedOp,(actualOp:'a option) = pair
+                actualOp.IsSome
             let idxToPath idx =
                 PathUtils.idToFullPath experimentRoot source.Output.Artefact.Id |> PathUtils.applyIndex idx
             let outputArtefact : Artefact =
-                expAndAct
-                |> toJaggedArrayOrValue (fun (index, v) -> { FullPath = idxToPath index; Index = index; UpdateType = pairToStatus v })
+                if expAndAct.IsScalar then
+                    // in case of scalar we do not utilize vector element delete feature. Thus always process
+                    upcast { FullPath = idxToPath []; Index = []; UpdateType = Process }
+                else
+                    let itemMapper =
+                        if expAndAct |> MdMap.toSeq |> Seq.exists (fun p -> let _,v = p in diskItemExists v ) then
+                            (fun (index, v) -> { FullPath = idxToPath index; Index = index; UpdateType = pairToStatus v })
+                        else
+                            // nothing is on disk. We hope the vector will be restored from storages. Thus Update type is not 'delete'
+                            (fun (index, _) -> { FullPath = idxToPath index; Index = index; UpdateType = Process }) 
+                    expAndAct
+                    |> toJaggedArrayOrValue itemMapper
 
             return Seq.singleton ([outputArtefact], null)
         } |> Async.RunSynchronously
@@ -88,7 +103,7 @@ type CommandMethod(command: CommandLineVertex,
             let fullIndex = vector.[0].Index
             let reducedIndex = fullIndex |> List.truncate (fullIndex.Length-1)
             let path = command.Inputs.[inputN].Artefact.Id |> PathUtils.idToFullPath experimentRoot |> PathUtils.applyIndex reducedIndex
-            { FullPath = path; Index = reducedIndex; UpdateType=Process } // TODO: use proper UpdateType
+            { FullPath = path; Index = reducedIndex; UpdateType=Process } // is it valid to always treat reduce as process and never as delete?
         else failwith "Input is empty (no artefacts to reduce)"
 
 
@@ -100,8 +115,11 @@ type CommandMethod(command: CommandLineVertex,
         
            
             // If any input, output is not valid we need to
-            //  1) restore inputs if they are absent on disk
-            //  2) execute the command
+            //  if input status brings 'delete'
+            //      1) we need to propagate the delete: delete disk content, output in delete ArtefactItem
+            //  otherwise
+            //      1) restore inputs if they are absent on disk
+            //      2) execute the command
             
             let inputItems = inputs |> List.mapi (fun i inp -> 
                 match inp with
@@ -123,100 +141,133 @@ type CommandMethod(command: CommandLineVertex,
             let logError str = Logger.logError Logger.Execution (sprintf "%s%A: %s" methodItemId index str)
             logVerbose "Started"
 
+            let deletedIndices =
+                let isDelete = function
+                    |   Delete -> true
+                    |   Process -> false
+                inputItems |> Seq.filter (fun item -> isDelete item.UpdateType) |> Seq.map (fun x -> x.Index) |> Seq.distinct |> Array.ofSeq
+
+
             // Build the full output paths by applying the index of this method.
             // Note that in case of scatter, these still might contain '*'
             let outputPaths = 
                 command.Outputs // the order is important here
                 |> List.map(fun out -> out.Artefact.Id |> PathUtils.idToFullPath experimentRoot |> applyIndex index)
+            if not (Array.isEmpty deletedIndices) then
+                // we need to delete the outputs in order to propagate input
+                logVerbose (sprintf "Deleting the outputs as input was deleted in vectorized operation")
+                let deleteDiskData (outputPath:string) =
+                    let deletePath path =
+                        logVerbose (sprintf "Deleting path %s" path)
+                        PathUtils.deletePath path
+                    if outputPath.Contains('*') then
+                        let outputItems = PathUtils.enumeratePath outputPath
+                        let paths = outputItems |> MdMap.toSeq |> Seq.map snd
+                        paths |> Seq.iter deletePath
+                    else
+                        deletePath outputPath
+                outputPaths |> Seq.iter deleteDiskData
 
-            let! currentVertexStatus = getCommandVertexStatus checkStoragePresence command index
+                do! command.OnSucceeded(index) // we erase the expectations for current index
+
+                let outPathToArtefactItem (outputPath:string) : Artefact =
+                    if outputPath.Contains('*') then
+                        let outputItems = PathUtils.enumeratePath outputPath
+                        outputItems |> toJaggedArrayOrValue (fun (extraIndex, itemFullPath) -> { FullPath = itemFullPath; Index = index @ extraIndex; UpdateType=Delete }) 
+                    else
+                        upcast { FullPath = outputPath; Index = index; UpdateType=Delete }
+                return Seq.singleton(outputPaths |> List.map outPathToArtefactItem, null)
+            else
+                // not vector element delete branch
+                let! currentVertexStatus = getCommandVertexStatus checkStoragePresence command index
        
-            match currentVertexStatus with
-            |   Outdated _ ->
-                // We need to do computation            
-                // 1) clearing the outputs if they exist   
-                // 2) restoring inputs from storage if it is needed
-                // 3) execute external command
-                // 4) upon 0 exit code hash the outputs
-                // 5) fill in corresponding method vertex (to fix proper versions)
-                // 6) write alph files for outputs
+                match currentVertexStatus with
+                |   Outdated _ ->
+                    // We need to do computation            
+                    // 1) clearing the outputs if they exist   
+                    // 2) restoring inputs from storage if it is needed
+                    // 3) execute external command
+                    // 4) upon 0 exit code hash the outputs
+                    // 5) fill in corresponding method vertex (to fix proper versions)
+                    // 6) write alph files for outputs
 
-                // 1) Deleting outputs
-                let recreatePath path =                    
-                    if not command.DoNotCleanOutputs then
-                        deletePath path
-                    ensureDirectories path
+                    // 1) Deleting outputs
+                    let recreatePath path =                    
+                        if not command.DoNotCleanOutputs then
+                            deletePath path
+                        ensureDirectories path
                 
-                outputPaths |> List.iter (fun path -> 
-                    if path.Contains '*' then 
-                        enumeratePath path |> MdMap.toSeq |> Seq.iter(fun (i,fullPath) -> recreatePath fullPath)
-                    else 
-                        recreatePath path)
+                    outputPaths |> List.iter (fun path -> 
+                        if path.Contains '*' then 
+                            enumeratePath path |> MdMap.toSeq |> Seq.iter(fun (i,fullPath) -> recreatePath fullPath)
+                        else 
+                            recreatePath path)
 
-                // 2) restoring inputs from storage if it is needed
-                let! hashesToRestorePerInput = 
-                    command.Inputs 
-                    |> Seq.map(getPathsToRestore index)
-                    |> Async.Parallel
-                let hashesToRestore =
-                    hashesToRestorePerInput
-                    |> Array.collect List.toArray
-                    |> Array.map(fun (path, hash) -> hash, path)
-                if Array.length hashesToRestore > 0 then
-                    let ct = logLongRunningStart (sprintf "Restoring missing inputs from storage...")
-                    do! restoreFromStorage hashesToRestore
-                    logLongRunningFinish ct (sprintf "Inputs are restored")
+                    // 2) restoring inputs from storage if it is needed
+                    let! hashesToRestorePerInput = 
+                        command.Inputs 
+                        |> Seq.map(getPathsToRestore index)
+                        |> Async.Parallel
+                    let hashesToRestore =
+                        hashesToRestorePerInput
+                        |> Array.collect List.toArray
+                        |> Array.map(fun (path, hash) -> hash, path)
+                    if Array.length hashesToRestore > 0 then
+                        let ct = logLongRunningStart (sprintf "Restoring missing inputs from storage...")
+                        do! restoreFromStorage hashesToRestore
+                        logLongRunningFinish ct (sprintf "Inputs are restored")
 
 
-                // 3) executing a command
-                let mutable exitCode = 0
-                let mutable aquiredResources = Set.empty
-                let mutable aquiringResources = Set.empty
-                try
-                    // acquiring resource semaphores
-                    let resourcesCt = logLongRunningStart "Waiting for system resources quota to become available"
-                    for resorceAqcAsync,resName in command.ResourceGroups |> Seq.sort |> Seq.map (fun g -> (Utils.enterResourceGroupMonitorAsync resourceSemaphores g),g) do
-                        aquiringResources <- Set.add resName aquiringResources
-                        do! resorceAqcAsync // in is crucial to lock the resources sequential and in ordered manner to prevent deadlocks
-                        aquiredResources <- Set.add resName aquiredResources
-                        logVerbose (sprintf "Got resource: %s" resName)
+                    // 3) executing a command
+                    let mutable exitCode = 0
+                    let mutable aquiredResources = Set.empty
+                    let mutable aquiringResources = Set.empty
+                    try
+                        // acquiring resource semaphores
+                        let resourcesCt = logLongRunningStart "Waiting for system resources quota to become available"
+                        for resorceAqcAsync,resName in command.ResourceGroups |> Seq.sort |> Seq.map (fun g -> (Utils.enterResourceGroupMonitorAsync resourceSemaphores g),g) do
+                            aquiringResources <- Set.add resName aquiringResources
+                            do! resorceAqcAsync // in is crucial to lock the resources sequential and in ordered manner to prevent deadlocks
+                            aquiredResources <- Set.add resName aquiredResources
+                            logVerbose (sprintf "Got resource: %s" resName)
 
-                    logLongRunningFinish resourcesCt "Obtained needed system resources quota"
-                    let print (s:string) = Logger.logInfo Logger.ExecutionOutput s
-                    let input idx = command.Inputs.[idx-1].Artefact.Id |> idToFullPath experimentRoot |> applyIndex index
-                    let output idx = command.Outputs.[idx-1].Artefact.Id |> idToFullPath experimentRoot |> applyIndex index
-                    let context : ComputationContext = { ExperimentRoot = experimentRoot; Print = print }
-                    let! exitCode2 = command |> ExecuteCommand.runCommandLineMethodAndWaitAsync context (input, output) 
-                    exitCode <- exitCode2
-                finally
-                    // releasing resource semaphores
-                    let notAquired = Set.difference aquiringResources aquiredResources
-                    if not (Set.isEmpty notAquired) then                        
-                        logError <| sprintf "Method could not success as failed to obtain the following resources: %A" notAquired
-                    aquiredResources |> Seq.iter (fun g -> Utils.exitResourceGroupMonitor (!resourceSemaphores) g)
+                        logLongRunningFinish resourcesCt "Obtained needed system resources quota"
+                        let print (s:string) = Logger.logInfo Logger.ExecutionOutput s
+                        let input idx = command.Inputs.[idx-1].Artefact.Id |> idToFullPath experimentRoot |> applyIndex index
+                        let output idx = command.Outputs.[idx-1].Artefact.Id |> idToFullPath experimentRoot |> applyIndex index
+                        let context : ComputationContext = { ExperimentRoot = experimentRoot; Print = print }
+                        let! exitCode2 = command |> ExecuteCommand.runCommandLineMethodAndWaitAsync context (input, output) 
+                        exitCode <- exitCode2
+                    finally
+                        // releasing resource semaphores
+                        let notAquired = Set.difference aquiringResources aquiredResources
+                        if not (Set.isEmpty notAquired) then                        
+                            logError <| sprintf "Method could not success as failed to obtain the following resources: %A" notAquired
+                        aquiredResources |> Seq.iter (fun g -> Utils.exitResourceGroupMonitor (!resourceSemaphores) g)
 
-                // 4) upon successful exit code hash the outputs
-                if not (Seq.exists (fun x -> exitCode = x) command.SuccessfulExitCodes) then
-                    raise(NonSuccessfulExitCodeException(sprintf "Process exited with non-successful exit code %d" exitCode))
-                else
-                    logInfo "Method succeeded"
-                    logVerbose (sprintf "Program succeeded. Calculating hashes of the outputs...")
-                    // 5a) hashing outputs disk content                
-                    // 5b) updating dependency versions in dependency graph
-                    // 6) dumping updated alph files to disk
-                    do! command.OnSucceeded(index)                    
-            |   UpToDate _ ->
-                logInfo "Up to date"
-            //comp.Outputs |> Seq.map (fun (output:DependencyGraph.VersionedArtefact) -> output.ExpectedVersion) |> List.ofSeq
+                    // 4) upon successful exit code hash the outputs
+                    if not (Seq.exists (fun x -> exitCode = x) command.SuccessfulExitCodes) then
+                        raise(NonSuccessfulExitCodeException(sprintf "Process exited with non-successful exit code %d" exitCode))
+                    else
+                        logInfo "Method succeeded"
+                        logVerbose (sprintf "Program succeeded. Calculating hashes of the outputs...")
+                        // 5a) hashing outputs disk content                
+                        // 5b) updating dependency versions in dependency graph
+                        // 6) dumping updated alph files to disk
+                        do! command.OnSucceeded(index)
+                |   UpToDate _ ->
+                    logInfo "Up to date"
+                //comp.Outputs |> Seq.map (fun (output:DependencyGraph.VersionedArtefact) -> output.ExpectedVersion) |> List.ofSeq
 
-            let outPathToArtefactItem (outputPath:string) : Artefact =
-                if outputPath.Contains('*') then
-                    let outputItems = PathUtils.enumeratePath outputPath
-                    outputItems |> toJaggedArrayOrValue (fun (extraIndex, itemFullPath) -> { FullPath = itemFullPath; Index = index @ extraIndex; UpdateType=Process }) // TODO: use proper UpdateType
-                else
-                    upcast { FullPath = outputPath; Index = index; UpdateType=Process } // TODO: use proper UpdateType
-            let result =  Seq.singleton(outputPaths |> List.map outPathToArtefactItem, null)
-            return result
+                let outPathToArtefactItem (outputPath:string) : Artefact =
+                    if outputPath.Contains('*') then
+                        let outputItems = PathUtils.enumeratePath outputPath
+                        outputItems |> toJaggedArrayOrValue (fun (extraIndex, itemFullPath) -> { FullPath = itemFullPath; Index = index @ extraIndex; UpdateType=Process })
+                    else
+                        upcast { FullPath = outputPath; Index = index; UpdateType=Process }
+                return Seq.singleton(outputPaths |> List.map outPathToArtefactItem, null)
+                    
+                
         } |> Async.RunSynchronously
 
 

--- a/AlpheusCore/ComputationGraph.fs
+++ b/AlpheusCore/ComputationGraph.fs
@@ -80,7 +80,8 @@ type SourceMethod(source: SourceVertex, experimentRoot) =
                     upcast { FullPath = idxToPath []; Index = []; UpdateType = Process }
                 else
                     let itemMapper =
-                        if expAndAct |> MdMap.toSeq |> Seq.exists (fun p -> let _,v = p in diskItemExists v ) then
+                        let vectorIsNotEmpty = expAndAct |> MdMap.toSeq |> Seq.exists (fun p -> let _,v = p in diskItemExists v )
+                        if vectorIsNotEmpty then
                             (fun (index, v) -> { FullPath = idxToPath index; Index = index; UpdateType = pairToStatus v })
                         else
                             // nothing is on disk. We hope the vector will be restored from storages. Thus Update type is not 'delete'

--- a/AlpheusCore/DependencyGraph.fs
+++ b/AlpheusCore/DependencyGraph.fs
@@ -269,7 +269,14 @@ and LinkToArtefact(artefact: ArtefactVertex, expectedVersion: ArtefactVersion) =
         if index.Length <> artefact.Rank then invalidArg "index" "Index doesn't correspond to the rank of the artefact"
         async {
             let! actual = artefact.ActualVersion.Get index
-            lock lockObj (fun() -> expected <- expected |> MdMap.add index actual)
+            lock lockObj (fun() ->
+                match actual with
+                |   Some(_) ->
+                    expected <- expected |> MdMap.add index actual
+                |   None ->
+                    // deleting this expectation from MdMap
+                    expected <- expected |> Utils.mdmapRemoveIfDefined index
+                )
             return ()
         }
 

--- a/AlpheusCore/Utils.fs
+++ b/AlpheusCore/Utils.fs
@@ -45,5 +45,18 @@ let exitResourceGroupMonitor monitors (groupName:string) =
     let simaphore: SemaphoreSlim = Map.find groupName monitors
     simaphore.Release() |> ignore
 
+/// returns the 'map' in which the 'key' is removed.
+/// if there is no element identified with 'key', the same 'map' is returned
+let mdmapRemoveIfDefined (key:'k list) (map:MdMap<'k,'v>) =
+    map
+    |> MdMap.toSeq
+    |> Seq.filter (fun p -> let k,_ = p in k <> key)
+    |> Seq.fold (fun s e -> let k,v = e in MdMap.add k v s) MdMap.empty
 
-
+let mdmapMerge (mapper: 'k list -> 'v option -> 'v option -> 'w) mdmap1 mdmap2 =
+    let firstKeys = mdmap1 |> MdMap.toSeq |> Seq.map fst |> Set.ofSeq
+    let secondKeys = mdmap2 |> MdMap.toSeq |> Seq.map fst |> Set.ofSeq
+    let unionKeys = Set.union firstKeys secondKeys
+    unionKeys
+    |> Seq.map (fun k -> k, (mapper k (MdMap.tryFind k mdmap1) (MdMap.tryFind k mdmap2)))
+    |> Seq.fold (fun s e -> let k,v = e in MdMap.add k v s) MdMap.empty

--- a/AlpheusUnitTests/ApiTests.Vectors.fs
+++ b/AlpheusUnitTests/ApiTests.Vectors.fs
@@ -181,11 +181,70 @@ type ``Vector scenarios``(output) as this =
                 cmd.Inputs.[0].Hash.IsScalar.Should().BeTrue("base.txt is scalar") |> ignore
                 (cmd.Inputs.[1].Hash |> MdMap.toShallowSeq |> Seq.length).Should().Be(3, "2nd input is a vector of 3 elements") |> ignore
                 (cmd.Outputs.[0].Hash |> MdMap.toShallowSeq |> Seq.length).Should().Be(3, "The output is a vector of 3 elements") |> ignore
-                Assert.True(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,v = x in k = ["4"]))
-                Assert.False(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,v = x in k = ["2"]))
+                Assert.True(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,_ = x in k = ["4"]))
+                Assert.False(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,_ = x in k = ["2"]))
             | _ -> failwith "Unexpected origin"
         }
 
+    [<Fact>]
+    member s.``Does not issue vector elements delete if currently no vector source elems on disk``() =
+        // consider the situation
+        // I added source vector artefact
+        // I saved it to storage
+        // I cloned the repo on another machine
+        // I run the experiment
+        // Expected: the system download best known saved vector indices to disk
+        // Possible wrong behavior: the system considers the vector as empty (as nothing on disk matches the * pattern)
+        async {
+            let root = s.ExperimentRoot 
+            do! prepareSources(root)
+
+            let! res = API.buildAsync root root ["base.txt"; "data/*.txt"] ["output/out*.txt"] concatCommand DependencyGraph.CommandExecutionSettings.Default
+            assertResultOk res
+
+            let dataId = ArtefactId.Path "data/*.txt"
+            let outputId = ArtefactId.Path "output/out*.txt"
+            let res = API.compute (root, outputId)
+            assertResultOk res
+
+            "Base fileFile 1" |> assertFileContent (Path.Combine(root, "output", "out1.txt"))
+            "Base fileFile 2" |> assertFileContent (Path.Combine(root, "output", "out2.txt"))
+            "Base fileFile 3" |> assertFileContent (Path.Combine(root, "output", "out3.txt"))
+
+            Logger.logInfo Logger.Test "saving data/out*.txt"
+
+            let! res = API.saveAsync (root,dataId) None false
+            assertResultOk res
+            
+            Logger.logInfo Logger.Test "Deleting data/*.txt and output/out*.txt"
+            File.Delete(Path.Combine(root,"data","1.txt"))
+            File.Delete(Path.Combine(root,"data","2.txt"))
+            File.Delete(Path.Combine(root,"data","3.txt"))
+            File.Delete(Path.Combine(root,"output","out1.txt"))
+            File.Delete(Path.Combine(root,"output","out2.txt"))
+            File.Delete(Path.Combine(root,"output","out3.txt"))
+            
+            //running again
+            Logger.logInfo Logger.Test "computing output/out*.txt again. data/*.txt restore must happen with previously existed indices [1;2;3]"
+            let res = API.compute (root, outputId)
+            assertResultOk res
+
+            "Base fileFile 1" |> assertFileContent (Path.Combine(root, "output", "out1.txt"))
+            "Base fileFile 2" |> assertFileContent (Path.Combine(root, "output", "out2.txt"))
+            "Base fileFile 3" |> assertFileContent (Path.Combine(root, "output", "out3.txt"))
+
+            // Checks the output alph file:
+            let alph = AlphFiles.tryLoad (PathUtils.idToAlphFileFullPath root outputId) |> Option.get
+            match alph.Origin with 
+            | DataOrigin.CommandOrigin cmd ->
+                cmd.Inputs.[0].Hash.IsScalar.Should().BeTrue("base.txt is scalar") |> ignore
+                (cmd.Inputs.[1].Hash |> MdMap.toShallowSeq |> Seq.length).Should().Be(3, "2nd input is a vector of 3 elements") |> ignore
+                (cmd.Outputs.[0].Hash |> MdMap.toShallowSeq |> Seq.length).Should().Be(3, "The output is a vector of 3 elements") |> ignore
+                Assert.True(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,_ = x in k = ["1"]))
+                Assert.True(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,_ = x in k = ["2"]))
+                Assert.True(cmd.Outputs.[0].Hash |> MdMap.toSeq |> Seq.exists (fun x -> let k,_ = x in k = ["3"]))
+            | _ -> failwith "Unexpected origin"
+        }
 
     [<Fact>]
     member s.``Re-Runs same method upon input changes``() =


### PR DESCRIPTION
Issue #89 fix by introducing notion of delete vector element operation during 

When some vector element (index) existed during previous runs of the command but now is absent, the system will propagate 'delete' operation which will delete the missing index from the outputs.